### PR TITLE
修复版本兼容问题

### DIFF
--- a/easyjson-jackson/pom.xml
+++ b/easyjson-jackson/pom.xml
@@ -16,6 +16,18 @@
     <description>
         Adapter easyjson to Jackson
     </description>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>

--- a/easyjson-jackson/src/main/java/com/jn/easyjson/jackson/Jacksons.java
+++ b/easyjson-jackson/src/main/java/com/jn/easyjson/jackson/Jacksons.java
@@ -41,6 +41,8 @@ public class Jacksons {
      */
     private static final Version CURRENT_VERSION;
 
+    private static final String JACKSON_CORE_PACKAGE_NAME = "com.fasterxml.jackson.core";
+
     public static boolean isJacksonJavaType(Type type) {
         return type instanceof JavaType;
     }
@@ -178,7 +180,7 @@ public class Jacksons {
      * @since 3.2.3
      */
     private static Version guessCurrentVersion() {
-        JsonFactory factory = Pipeline.of(ServiceLoader.<JsonFactory>load(JsonFactory.class)).findFirst();
+        JsonFactory factory = Pipeline.of(ServiceLoader.load(JsonFactory.class)).filter(e -> JACKSON_CORE_PACKAGE_NAME.equals(e.getClass().getPackage().getName())).findFirst();
         Version template = factory.version();
 
         Version version = new Version(template.getMajorVersion(), template.getMinorVersion(), template.getPatchLevel(), null, null, null);


### PR DESCRIPTION
### 提交描述：
修复easyjson-jackson包中Jacksons.guessCurrentVersion方法获取jackson版本有误的问题。
### 问题描述：
如果项目中引用了jackson-dataformat-yaml，且jackson版本低于2.9.0，jackson-dataformat-yaml版本高于2.9.7，会导致获取jackson版本的时候获取的是jackson-dataformat-yaml的版本号，反序列化就会出NPE
<version.jackson-dataformat-yaml>2.9.7</version.jackson-dataformat-yaml>
<version.jackson>2.6.0</version.jackson>
<version.easyjson-core>3.2.3</version.easyjson-core>
### 问题原因：
获取jackson版本号是通过JsonFactory的version方法来获取的，jackson-dataformat-yaml中的YAMLFactory继承了jackson的JsonFactory，获取的时候通过
JsonFactory factory = Pipeline.of(ServiceLoader.<JsonFactory>load(JsonFactory.class)).findFirst();
获取有误
### 修复方案：
获取的时候排除一下非 “com.fasterxml.jackson.core”包下的JsonFactory
JsonFactory factory = Pipeline.of(ServiceLoader.load(JsonFactory.class)).filter(e -> JACKSON_CORE_PACKAGE_NAME.equals(e.getClass().getPackage().getName())).findFirst();